### PR TITLE
fix: unity ping response handling

### DIFF
--- a/Packages/src/TypeScriptServer/dist/server.bundle.js
+++ b/Packages/src/TypeScriptServer/dist/server.bundle.js
@@ -6228,13 +6228,32 @@ var SimpleMcpServer = class {
       await this.unityClient.ensureConnected();
       const response = await this.unityClient.ping(message);
       const port = process.env.UNITY_TCP_PORT || "7400";
+      let responseText = "";
+      if (typeof response === "object" && response !== null) {
+        const respObj = response;
+        DebugLogger.debug("[UnityPing] Response object properties:", {
+          Message: respObj.Message,
+          StartedAt: respObj.StartedAt,
+          EndedAt: respObj.EndedAt,
+          ExecutionTimeMs: respObj.ExecutionTimeMs
+        });
+        responseText = `Message: ${respObj.Message || "No message"}`;
+        if (respObj.StartedAt && respObj.EndedAt && respObj.ExecutionTimeMs !== void 0) {
+          responseText += `
+Started: ${respObj.StartedAt}
+Ended: ${respObj.EndedAt}
+Execution Time: ${respObj.ExecutionTimeMs}ms`;
+        }
+      } else {
+        responseText = String(response);
+      }
       return {
         content: [
           {
             type: "text",
             text: `Unity Ping Success!
 Sent: ${message}
-Response: ${response}
+Response: ${responseText}
 Connection: TCP/IP established on port ${port}`
           }
         ]

--- a/Packages/src/TypeScriptServer/src/server.ts
+++ b/Packages/src/TypeScriptServer/src/server.ts
@@ -267,13 +267,37 @@ class SimpleMcpServer {
       const response = await this.unityClient.ping(message);
       const port = process.env.UNITY_TCP_PORT || '7400';
       
+      // Handle the new BaseCommandResponse format with timing info
+      let responseText = '';
+      if (typeof response === 'object' && response !== null) {
+        const respObj = response as any;
+        DebugLogger.debug('[UnityPing] Response object properties:', {
+          Message: respObj.Message,
+          StartedAt: respObj.StartedAt,
+          EndedAt: respObj.EndedAt,
+          ExecutionTimeMs: respObj.ExecutionTimeMs
+        });
+        
+        responseText = `Message: ${respObj.Message || 'No message'}`;
+        
+        // Add timing information if available
+        if (respObj.StartedAt && respObj.EndedAt && respObj.ExecutionTimeMs !== undefined) {
+          responseText += `
+Started: ${respObj.StartedAt}
+Ended: ${respObj.EndedAt}
+Execution Time: ${respObj.ExecutionTimeMs}ms`;
+        }
+      } else {
+        responseText = String(response);
+      }
+      
       return {
         content: [
           {
             type: 'text',
             text: `Unity Ping Success!
 Sent: ${message}
-Response: ${response}
+Response: ${responseText}
 Connection: TCP/IP established on port ${port}`
           }
         ]


### PR DESCRIPTION
- Updated the response handling in SimpleMcpServer to accommodate the new BaseCommandResponse format.
- Added detailed logging for response properties including Message, StartedAt, EndedAt, and ExecutionTimeMs.
- Improved the response text format to include timing information when available, enhancing clarity for debugging and monitoring.