### PR TITLE
fix: update release-please workflow paths for hidden .TypeScriptServer directory

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 🧪 Sanity check
         run: |
           test -f Packages/src/package.json && echo "✅ Unity package.json OK"
-          test -f Packages/src/TypeScriptServer/package.json && echo "✅ TypeScript package.json OK"
+          test -f Packages/src/.TypeScriptServer/package.json && echo "✅ TypeScript package.json OK"
 
       # ── Execute release-please ───────────────────────────
       - name: 🚀 Run release‑please
@@ -47,4 +47,4 @@ jobs:
           package-name: "io.github.hatayama.umcp"
           token: ${{ secrets.GITHUB_TOKEN }}
           extra-files: |
-            TypeScriptServer/package.json
+            .TypeScriptServer/package.json


### PR DESCRIPTION
## Summary
Fix release-please workflow to use correct path for hidden `.TypeScriptServer` directory.

## Problem
The release-please workflow was referencing the old `TypeScriptServer` directory path, causing sanity check failures and preventing proper package version management.

## Changes Made
- Updated sanity check path: `Packages/src/TypeScriptServer/package.json` → `Packages/src/.TypeScriptServer/package.json`
- Updated extra-files path: `TypeScriptServer/package.json` → `.TypeScriptServer/package.json`

## Test Plan
- [ ] Verify workflow runs without path errors
- [ ] Confirm sanity check passes with new path
- [ ] Test release-please can find and update TypeScript package.json
- [ ] Validate no regression in release process

## Impact
This fixes the failing release-please workflow that was broken by the directory structure change to use hidden `.TypeScriptServer` directory.