### PR TITLE
feat: implement dynamic client naming using MCP protocol

### DIFF
--- a/Packages/src/.TypeScriptServer/dist/server.bundle.js
+++ b/Packages/src/.TypeScriptServer/dist/server.bundle.js
@@ -6215,7 +6215,7 @@ var DEV_TOOL_PING_NAME = "mcp-ping";
 var DEV_TOOL_PING_DESCRIPTION = "TypeScript side health check (dev only)";
 var DEV_TOOL_COMMANDS_NAME = "get-unity-commands";
 var DEV_TOOL_COMMANDS_DESCRIPTION = "Get Unity commands list (dev only)";
-var DEFAULT_CLIENT_NAME = "MCP Client";
+var DEFAULT_CLIENT_NAME = "";
 
 // package.json
 var package_default = {
@@ -6334,11 +6334,15 @@ var SimpleMcpServer = class {
   async initializeDynamicTools() {
     try {
       await this.unityClient.ensureConnected();
-      if (!this.clientName || this.clientName === DEFAULT_CLIENT_NAME) {
-        const fallbackName = process.env.MCP_CLIENT_NAME || DEFAULT_CLIENT_NAME;
-        this.clientName = fallbackName;
-        await this.unityClient.setClientName(fallbackName);
-        infoToFile(`[Simple MCP] Fallback client name set to Unity: ${fallbackName}`);
+      if (!this.clientName) {
+        const fallbackName = process.env.MCP_CLIENT_NAME;
+        if (fallbackName) {
+          this.clientName = fallbackName;
+          await this.unityClient.setClientName(fallbackName);
+          infoToFile(`[Simple MCP] Fallback client name set to Unity: ${fallbackName}`);
+        } else {
+          infoToFile(`[Simple MCP] No client name set, waiting for initialize request`);
+        }
       } else {
         await this.unityClient.setClientName(this.clientName);
         infoToFile(`[Simple MCP] Client name already set, sending to Unity: ${this.clientName}`);

--- a/Packages/src/.TypeScriptServer/src/mcp-constants.ts
+++ b/Packages/src/.TypeScriptServer/src/mcp-constants.ts
@@ -22,4 +22,4 @@ export const DEV_TOOL_COMMANDS_NAME = 'get-unity-commands';
 export const DEV_TOOL_COMMANDS_DESCRIPTION = 'Get Unity commands list (dev only)';
 
 // Client Name Constants
-export const DEFAULT_CLIENT_NAME = 'MCP Client';
+export const DEFAULT_CLIENT_NAME = ''; // Empty string to avoid showing default names

--- a/Packages/src/.TypeScriptServer/src/mcp-constants.ts
+++ b/Packages/src/.TypeScriptServer/src/mcp-constants.ts
@@ -1,0 +1,22 @@
+/**
+ * MCP Server Constants
+ *
+ * Centralized constants for the Unity MCP server implementation
+ */
+
+// MCP Protocol Constants
+export const MCP_PROTOCOL_VERSION = '2024-11-05';
+
+// Server Information
+export const MCP_SERVER_NAME = 'umcp-server';
+
+// Capabilities
+export const TOOLS_LIST_CHANGED_CAPABILITY = true;
+
+// Development Tools
+export const DEV_TOOL_PING_NAME = 'mcp-ping';
+export const DEV_TOOL_PING_DESCRIPTION = 'TypeScript side health check (dev only)';
+export const DEV_TOOL_PING_DEFAULT_MESSAGE = 'Hello Unity MCP!';
+
+export const DEV_TOOL_COMMANDS_NAME = 'get-unity-commands';
+export const DEV_TOOL_COMMANDS_DESCRIPTION = 'Get Unity commands list (dev only)';

--- a/Packages/src/.TypeScriptServer/src/mcp-constants.ts
+++ b/Packages/src/.TypeScriptServer/src/mcp-constants.ts
@@ -20,3 +20,6 @@ export const DEV_TOOL_PING_DEFAULT_MESSAGE = 'Hello Unity MCP!';
 
 export const DEV_TOOL_COMMANDS_NAME = 'get-unity-commands';
 export const DEV_TOOL_COMMANDS_DESCRIPTION = 'Get Unity commands list (dev only)';
+
+// Client Name Constants
+export const DEFAULT_CLIENT_NAME = 'MCP Client';

--- a/Packages/src/.TypeScriptServer/src/server.ts
+++ b/Packages/src/.TypeScriptServer/src/server.ts
@@ -5,12 +5,22 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  InitializeRequestSchema,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { UnityClient } from './unity-client.js';
 import { DynamicUnityCommandTool } from './tools/dynamic-unity-command-tool.js';
 import { errorToFile, debugToFile, infoToFile } from './utils/log-to-file.js';
 import { ENVIRONMENT, DEFAULT_MESSAGES } from './constants.js';
+import {
+  MCP_PROTOCOL_VERSION,
+  MCP_SERVER_NAME,
+  TOOLS_LIST_CHANGED_CAPABILITY,
+  DEV_TOOL_PING_NAME,
+  DEV_TOOL_PING_DESCRIPTION,
+  DEV_TOOL_COMMANDS_NAME,
+  DEV_TOOL_COMMANDS_DESCRIPTION,
+} from './mcp-constants.js';
 import packageJson from '../package.json' assert { type: 'json' };
 import { ToolResponse } from './types/tool-types.js';
 
@@ -29,6 +39,7 @@ class SimpleMcpServer {
   private readonly dynamicTools: Map<string, DynamicUnityCommandTool> = new Map();
   private isShuttingDown: boolean = false;
   private isRefreshing: boolean = false;
+  private clientName: string = 'MCP Client';
 
   constructor() {
     // Simple environment variable check
@@ -40,13 +51,13 @@ class SimpleMcpServer {
 
     this.server = new Server(
       {
-        name: 'umcp-server',
+        name: MCP_SERVER_NAME,
         version: packageJson.version,
       },
       {
         capabilities: {
           tools: {
-            listChanged: true,
+            listChanged: TOOLS_LIST_CHANGED_CAPABILITY,
           },
         },
       },
@@ -69,6 +80,14 @@ class SimpleMcpServer {
   private async initializeDynamicTools(): Promise<void> {
     try {
       await this.unityClient.ensureConnected();
+
+      // Set fallback client name only if not already set via initialize request
+      if (!this.clientName) {
+        const fallbackName = process.env.MCP_CLIENT_NAME || 'MCP Client';
+        this.clientName = fallbackName;
+        await this.unityClient.setClientName(fallbackName);
+        infoToFile(`[Simple MCP] Fallback client name set to Unity: ${fallbackName}`);
+      }
 
       // Get detailed command information including schemas
       const commandDetailsResponse = await this.unityClient.executeCommand('getCommandDetails', {});
@@ -149,6 +168,33 @@ class SimpleMcpServer {
   }
 
   private setupHandlers(): void {
+    // Handle initialize request to get client information
+    this.server.setRequestHandler(InitializeRequestSchema, async (request) => {
+      const clientInfo = request.params?.clientInfo;
+      if (clientInfo?.name) {
+        this.clientName = clientInfo.name;
+        infoToFile(`[Simple MCP] Client name received: ${this.clientName}`);
+
+        // Immediately send client name to Unity if connected
+        if (this.unityClient) {
+          void this.unityClient.setClientName(this.clientName);
+        }
+      }
+
+      return {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {
+          tools: {
+            listChanged: TOOLS_LIST_CHANGED_CAPABILITY,
+          },
+        },
+        serverInfo: {
+          name: MCP_SERVER_NAME,
+          version: packageJson.version,
+        },
+      };
+    });
+
     // Provide tool list
     this.server.setRequestHandler(ListToolsRequestSchema, () => {
       const tools: Tool[] = [];
@@ -165,8 +211,8 @@ class SimpleMcpServer {
       // Development tools (only in development mode)
       if (this.isDevelopment) {
         tools.push({
-          name: 'mcp-ping',
-          description: 'TypeScript side health check (dev only)',
+          name: DEV_TOOL_PING_NAME,
+          description: DEV_TOOL_PING_DESCRIPTION,
           inputSchema: {
             type: 'object',
             properties: {
@@ -180,8 +226,8 @@ class SimpleMcpServer {
         });
 
         tools.push({
-          name: 'get-unity-commands',
-          description: 'Get Unity commands list (dev only)',
+          name: DEV_TOOL_COMMANDS_NAME,
+          description: DEV_TOOL_COMMANDS_DESCRIPTION,
           inputSchema: {
             type: 'object',
             properties: {},
@@ -228,12 +274,12 @@ class SimpleMcpServer {
         }
 
         switch (name) {
-          case 'mcp-ping':
+          case DEV_TOOL_PING_NAME:
             if (this.isDevelopment) {
               return await this.handlePing(args as { message?: string });
             }
             throw new Error('Development tool not available in production');
-          case 'get-unity-commands':
+          case DEV_TOOL_COMMANDS_NAME:
             if (this.isDevelopment) {
               return await this.handleGetAvailableCommands();
             }

--- a/Packages/src/.TypeScriptServer/src/server.ts
+++ b/Packages/src/.TypeScriptServer/src/server.ts
@@ -82,12 +82,16 @@ class SimpleMcpServer {
     try {
       await this.unityClient.ensureConnected();
 
-      // Set fallback client name only if still using default value or not set
-      if (!this.clientName || this.clientName === DEFAULT_CLIENT_NAME) {
-        const fallbackName = process.env.MCP_CLIENT_NAME || DEFAULT_CLIENT_NAME;
-        this.clientName = fallbackName;
-        await this.unityClient.setClientName(fallbackName);
-        infoToFile(`[Simple MCP] Fallback client name set to Unity: ${fallbackName}`);
+      // Set fallback client name only if still using default value (empty string) or not set
+      if (!this.clientName) {
+        const fallbackName = process.env.MCP_CLIENT_NAME;
+        if (fallbackName) {
+          this.clientName = fallbackName;
+          await this.unityClient.setClientName(fallbackName);
+          infoToFile(`[Simple MCP] Fallback client name set to Unity: ${fallbackName}`);
+        } else {
+          infoToFile(`[Simple MCP] No client name set, waiting for initialize request`);
+        }
       } else {
         // Send the already set client name to Unity
         await this.unityClient.setClientName(this.clientName);

--- a/Packages/src/.TypeScriptServer/src/unity-client.ts
+++ b/Packages/src/.TypeScriptServer/src/unity-client.ts
@@ -166,17 +166,10 @@ export class UnityClient {
     return new Promise((resolve, reject) => {
       this.socket = new net.Socket();
 
-      this.socket.connect(this.port, this.host, async () => {
+      this.socket.connect(this.port, this.host, () => {
         this._connected = true;
 
-        // Send client name to Unity for identification
-        try {
-          await this.setClientName();
-        } catch (error) {
-          errorToFile('[UnityClient] Failed to set client name:', error);
-        }
-
-        // Notify reconnect handlers
+        // Notify reconnect handlers (this will handle client name setting)
         this.reconnectHandlers.forEach((handler) => {
           try {
             handler();

--- a/Packages/src/.TypeScriptServer/src/unity-client.ts
+++ b/Packages/src/.TypeScriptServer/src/unity-client.ts
@@ -230,20 +230,20 @@ export class UnityClient {
   /**
    * Send client name to Unity for identification
    */
-  async setClientName(): Promise<void> {
+  async setClientName(clientName?: string): Promise<void> {
     if (!this.connected) {
       return; // Skip if not connected
     }
 
-    // Detect client name from environment or process
-    const clientName = this.detectClientName();
+    // Use provided client name or fallback to environment detection
+    const finalClientName = clientName || this.detectClientName();
 
     const request = {
       jsonrpc: JSONRPC.VERSION,
       id: this.generateId(),
       method: 'setClientName',
       params: {
-        ClientName: clientName,
+        ClientName: finalClientName,
       },
     };
 

--- a/Packages/src/.TypeScriptServer/src/utils/log-to-file.ts
+++ b/Packages/src/.TypeScriptServer/src/utils/log-to-file.ts
@@ -27,11 +27,13 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
 // Create log file path with timestamp
 // Find project root by looking for specific Unity project files
 const findProjectRoot = (): string => {
-  let currentDir = __dirname;
+  const __filename = fileURLToPath(import.meta.url);
+  let currentDir = path.dirname(__filename);
   let searchDepth = 0;
   const maxSearchDepth = 10; // Prevent infinite loops
 

--- a/Packages/src/Editor/Config/McpConfigService.cs
+++ b/Packages/src/Editor/Config/McpConfigService.cs
@@ -161,9 +161,8 @@ namespace io.github.hatayama.uMCP
             updatedEnv.Remove(McpConstants.ENV_KEY_NODE_ENV);
             updatedEnv.Remove(McpConstants.ENV_KEY_MCP_DEBUG);
             
-            // Ensure MCP_CLIENT_NAME is set correctly for this editor type
-            string clientName = McpConstants.GetClientNameForEditor(_editorType);
-            updatedEnv[McpConstants.ENV_KEY_MCP_CLIENT_NAME] = clientName;
+            // Remove MCP_CLIENT_NAME - now using clientInfo.name from MCP protocol
+            updatedEnv.Remove(McpConstants.ENV_KEY_MCP_CLIENT_NAME);
             
             // Add NODE_ENV for development mode (simplified approach)
             if (developmentMode)

--- a/Packages/src/Editor/Config/McpConstants.cs
+++ b/Packages/src/Editor/Config/McpConstants.cs
@@ -70,6 +70,9 @@ namespace io.github.hatayama.uMCP
         public const string SESSION_KEY_RECONNECTING = "uMCP.Reconnecting";
         public const string SESSION_KEY_SHOW_RECONNECTING_UI = "uMCP.ShowReconnectingUI";
         
+        // EditorPrefs keys
+        public const string EDITOR_PREFS_SHOW_RECONNECTING_UI = "uMCP_ShowReconnectingUI";
+        
         /// <summary>
         /// Gets the client name for the specified editor type
         /// </summary>

--- a/Packages/src/Editor/Config/McpServerConfigFactory.cs
+++ b/Packages/src/Editor/Config/McpServerConfigFactory.cs
@@ -19,8 +19,8 @@ namespace io.github.hatayama.uMCP
         {
             Dictionary<string, string> env = new Dictionary<string, string>
             {
-                { McpConstants.UNITY_TCP_PORT_ENV_KEY, port.ToString() },
-                { McpConstants.ENV_KEY_MCP_CLIENT_NAME, McpConstants.GetClientNameForEditor(editorType) }
+                { McpConstants.UNITY_TCP_PORT_ENV_KEY, port.ToString() }
+                // MCP_CLIENT_NAME removed - now using clientInfo.name from MCP protocol
             };
 
             return new McpServerConfigData(

--- a/Packages/src/Editor/Server/McpServerController.cs
+++ b/Packages/src/Editor/Server/McpServerController.cs
@@ -120,6 +120,7 @@ namespace io.github.hatayama.uMCP
                 SessionState.SetBool(McpConstants.SESSION_KEY_AFTER_COMPILE, true); // Set the post-compilation flag.
                 SessionState.SetBool(McpConstants.SESSION_KEY_RECONNECTING, true); // Set the reconnecting flag.
                 SessionState.SetBool(McpConstants.SESSION_KEY_SHOW_RECONNECTING_UI, true); // Set the UI display flag.
+                EditorPrefs.SetBool(McpConstants.EDITOR_PREFS_SHOW_RECONNECTING_UI, true); // Also save to EditorPrefs for persistence
                 
                 // Force-save the communication log as well.
                 McpCommunicationLogger.SaveToSessionState();
@@ -473,6 +474,7 @@ namespace io.github.hatayama.uMCP
             {
                 McpLogger.LogDebug("[RECONNECTION UI] Timeout reached, clearing UI display flag");
                 SessionState.EraseBool(McpConstants.SESSION_KEY_SHOW_RECONNECTING_UI);
+                EditorPrefs.DeleteKey(McpConstants.EDITOR_PREFS_SHOW_RECONNECTING_UI); // Also clear EditorPrefs
             }
         }
         
@@ -494,6 +496,7 @@ namespace io.github.hatayama.uMCP
             if (wasShowingUI)
             {
                 SessionState.EraseBool(McpConstants.SESSION_KEY_SHOW_RECONNECTING_UI);
+                EditorPrefs.DeleteKey(McpConstants.EDITOR_PREFS_SHOW_RECONNECTING_UI); // Also clear EditorPrefs
                 McpLogger.LogDebug("[RECONNECTION UI] Client connected, cleared UI display flag");
             }
         }

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -229,13 +229,13 @@ namespace io.github.hatayama.uMCP
                 showDebugCallback: () =>
                 {
                     string debugInfo = McpServerController.GetDetailedServerStatus();
-                    Debug.Log($"MCP Server Debug Info:\n{debugInfo}");
+                    McpLogger.LogInfo($"MCP Server Debug Info:\n{debugInfo}");
                 },
                 notifyChangesCallback: () => NotifyCommandChanges(),
                 rebuildCallback: () =>
                 {
                     // TypeScript rebuild functionality moved to View layer
-                    Debug.Log("TypeScript rebuild not implemented in this version");
+                    McpLogger.LogInfo("TypeScript rebuild not implemented in this version");
                 });
 #endif
 

--- a/Packages/src/Editor/UI/McpEditorWindow.cs
+++ b/Packages/src/Editor/UI/McpEditorWindow.cs
@@ -289,8 +289,15 @@ namespace io.github.hatayama.uMCP
         private ConnectedToolsData CreateConnectedToolsData()
         {
             bool isServerRunning = McpServerController.IsServerRunning;
-            bool showReconnectingUI = SessionState.GetBool(McpConstants.SESSION_KEY_SHOW_RECONNECTING_UI, false);
             var connectedClients = McpServerController.CurrentServer?.GetConnectedClients();
+            
+            // Check both SessionState and EditorPrefs for reconnecting UI flag
+            bool sessionReconnecting = SessionState.GetBool(McpConstants.SESSION_KEY_SHOW_RECONNECTING_UI, false);
+            bool editorPrefsReconnecting = EditorPrefs.GetBool(McpConstants.EDITOR_PREFS_SHOW_RECONNECTING_UI, false);
+            bool hasClients = connectedClients != null && connectedClients.Count > 0;
+            
+            // Don't show reconnecting if clients are already connected
+            bool showReconnectingUI = (sessionReconnecting || editorPrefsReconnecting) && !hasClients;
 
             return new ConnectedToolsData(connectedClients, _model.UI.ShowConnectedTools, isServerRunning, showReconnectingUI);
         }

--- a/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowEventHandler.cs
@@ -119,6 +119,9 @@ namespace io.github.hatayama.uMCP
                 }
             }
             
+            // Clear reconnecting flags when client connects
+            McpServerController.ClearReconnectingFlag();
+            
             // Mark that repaint is needed since events are called from background thread
             _model.RequestRepaint();
 

--- a/Packages/src/Editor/UI/McpEditorWindowView.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowView.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEditor;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace io.github.hatayama.uMCP
 {
@@ -186,19 +187,28 @@ namespace io.github.hatayama.uMCP
             if (data.ShowReconnectingUI)
             {
                 EditorGUILayout.HelpBox(McpUIConstants.RECONNECTING_MESSAGE, MessageType.Info);
-                return;
             }
-            
-            if (data.Clients != null && data.Clients.Count > 0)
+            else if (data.Clients != null && data.Clients.Count > 0)
             {
-                foreach (ConnectedClient client in data.Clients)
+                // Filter out clients with default or unknown names
+                var validClients = data.Clients.Where(client => IsValidClientName(client.ClientName)).ToList();
+                
+                if (validClients.Count > 0)
                 {
-                    DrawConnectedClientItem(client);
+                    foreach (ConnectedClient client in validClients)
+                    {
+                        DrawConnectedClientItem(client);
+                    }
+                }
+                else
+                {
+                    // All clients have invalid names, show as if no clients
+                    EditorGUILayout.HelpBox("No connected tools found.", MessageType.Info);
                 }
             }
             else
             {
-                EditorGUILayout.HelpBox("No LLM tools currently connected.", MessageType.Info);
+                EditorGUILayout.HelpBox("No connected tools found.", MessageType.Info);
             }
         }
 
@@ -508,5 +518,14 @@ namespace io.github.hatayama.uMCP
             EditorGUILayout.EndScrollView();
         }
 #endif
+
+        /// <summary>
+        /// Check if client name is valid for display (not empty)
+        /// </summary>
+        private bool IsValidClientName(string clientName)
+        {
+            // Only show clients with non-empty names (default is empty string)
+            return !string.IsNullOrEmpty(clientName);
+        }
     }
 } 


### PR DESCRIPTION
## Summary

* **Dynamic client naming**: Modified MCP server to use `clientInfo.name` from MCP protocol instead of hardcoded environment variables
* **TypeScript code quality**: Added comprehensive ESLint and Prettier configuration with pre-commit hooks
* **Constants refactoring**: Extracted hardcoded values into centralized constants for better maintainability
* **UI improvements**: Fixed reconnecting display logic and prevented transient default client name display

## Technical Changes

### MCP Protocol Implementation
- Added initialize request handler to capture `clientInfo.name` from MCP protocol
- Removed dependency on `MCP_CLIENT_NAME` environment variable in C# configuration
- Implemented dynamic client name transmission to Unity during connection

### Code Quality Improvements
- Added ESLint with TypeScript support and comprehensive rule set
- Integrated Prettier for consistent code formatting
- Set up Husky pre-commit hooks with lint-staged for automated quality checks
- Fixed ES module compatibility issues (`__dirname` → `import.meta.url`)

### Constants Refactoring
- Created `mcp-constants.ts` for centralized constant management
- Replaced hardcoded protocol version "2024-11-05" with `MCP_PROTOCOL_VERSION`
- Unified server naming and capability flags through constants

### UI/UX Enhancements
- Fixed reconnecting message display using both SessionState and EditorPrefs
- Prevented brief display of default client names ("MCP Client", "Unknown Client")
- Added client name filtering to ensure only valid names are displayed

## Test plan

- [ ] Verify MCP server recognizes client names from different tools (Cursor, Claude Code)
- [ ] Test reconnection behavior after Unity compilation
- [ ] Confirm ESLint and Prettier rules are enforced on commit
- [ ] Validate that default client names no longer appear in UI
- [ ] Check that reconnecting message displays properly and clears correctly

## Breaking Changes

None. This is backward compatible as it falls back to environment variable if no clientInfo is provided.

## Related Issues

Addresses the dynamic client naming requirement for MCP protocol compliance.