### PR TITLE
fix: prevent "Unknown Client" display on initial connection

### DIFF
--- a/Packages/src/.TypeScriptServer/dist/server.bundle.js
+++ b/Packages/src/.TypeScriptServer/dist/server.bundle.js
@@ -6494,12 +6494,8 @@ var UnityMcpServer = class {
       if (!this.isInitialized) {
         this.isInitialized = true;
         infoToFile(`[Unity MCP] Initializing Unity connection with client name: ${this.clientName}`);
-        try {
-          await this.initializeDynamicTools();
-          infoToFile("[Unity MCP] Unity connection established successfully");
-        } catch (error) {
-          errorToFile("[Unity MCP] Failed to initialize Unity connection:", error);
-        }
+        await this.initializeDynamicTools();
+        infoToFile("[Unity MCP] Unity connection established successfully");
       }
       return {
         protocolVersion: MCP_PROTOCOL_VERSION,

--- a/Packages/src/.TypeScriptServer/src/server.ts
+++ b/Packages/src/.TypeScriptServer/src/server.ts
@@ -232,13 +232,8 @@ class UnityMcpServer {
         this.isInitialized = true;
         infoToFile(`[Unity MCP] Initializing Unity connection with client name: ${this.clientName}`);
         
-        try {
-          await this.initializeDynamicTools();
-          infoToFile('[Unity MCP] Unity connection established successfully');
-        } catch (error) {
-          errorToFile('[Unity MCP] Failed to initialize Unity connection:', error);
-          // Continue anyway - tools can be loaded later via refresh
-        }
+        await this.initializeDynamicTools();
+        infoToFile('[Unity MCP] Unity connection established successfully');
       }
 
       return {

--- a/Packages/src/Editor/UI/McpEditorWindowView.cs
+++ b/Packages/src/Editor/UI/McpEditorWindowView.cs
@@ -521,12 +521,13 @@ namespace io.github.hatayama.uMCP
 #endif
 
         /// <summary>
-        /// Check if client name is valid for display (not empty)
+        /// Check if client name is valid for display
         /// </summary>
         private bool IsValidClientName(string clientName)
         {
-            // Only show clients with non-empty names (default is empty string)
-            return !string.IsNullOrEmpty(clientName);
+            // Only show clients with properly set names
+            // Filter out empty names and the default "Unknown Client" placeholder
+            return !string.IsNullOrEmpty(clientName) && clientName != McpConstants.UNKNOWN_CLIENT_NAME;
         }
     }
 } 


### PR DESCRIPTION
## Overview
This PR fixes the "Unknown Client" display issue that appears briefly when a new MCP client connects to Unity. The fix delays the Unity connection until after the MCP client name is received, ensuring proper client identification from the first connection.

## Details
### Problem
- When the TypeScript server started, it immediately connected to Unity before receiving the client name from the MCP client
- This caused Unity to display "Unknown Client" temporarily until the proper client name was received
- The issue was particularly noticeable in the Unity Editor UI

### Solution
- Modified the connection flow to wait for the MCP client's `initialize` request before connecting to Unity
- Added an `isInitialized` flag to prevent duplicate connections
- Moved the `initializeDynamicTools()` call from the `start()` method to the `InitializeRequestSchema` handler
- Updated both TypeScript and Unity architecture documentation to reflect the new connection flow

### Technical Changes
1. **TypeScript Server (`server.ts`)**:
   - Added `isInitialized` flag to track first-time initialization
   - Modified `start()` method to connect to MCP transport first and wait for client
   - Moved Unity connection logic to `InitializeRequestSchema` handler

2. **Documentation Updates**:
   - Updated server startup workflow in TypeScript ARCHITECTURE.md
   - Added "Client Identification Flow" section to Unity ARCHITECTURE.md
   - Documented the delayed connection mechanism

## Related Documents
- [uMCP Documentation](https://github.com/hatayama/uMCP)
- [Model Context Protocol Specification](https://spec.modelcontextprotocol.io/)