### PR TITLE
fix: GitHub Actions workflow improvements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,6 @@ name: Build and Release uMCP
 
 on:
   push:
-    branches: [ main ]
     tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
@@ -65,7 +64,7 @@ jobs:
         echo "Note: node_modules will be automatically cleaned up when GitHub Actions environment is destroyed"
         
     - name: Commit built files (if changed)
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: github.event_name == 'pull_request'
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
@@ -84,7 +83,7 @@ jobs:
           - dist/server.bundle.js
           
           Note: node_modules/ is excluded by .gitignore"
-          git push
+          git push origin HEAD:${{ github.head_ref }}
           echo "Built files committed successfully"
         fi
         

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -96,6 +96,11 @@ jobs:
     name: TypeScript Security Analysis
     runs-on: ubuntu-latest
     
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fix CodeQL SARIF upload permission error by adding security-events write permission to TypeScript security job
- Remove main branch push trigger to enforce PR-only workflow as per CLAUDE.md guidelines
- Update TypeScript build to commit built files to PR branch instead of main branch

## Changes
- Added missing permissions to typescript-security job in security-scan.yml
- Removed main branch from push triggers in build-and-test.yml  
- Modified commit logic to push to PR branch using HEAD:github.head_ref

## Test plan
- [ ] Verify CodeQL SARIF upload works without permission errors
- [ ] Confirm TypeScript builds are committed to PR branches
- [ ] Ensure main branch direct push is blocked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow triggers to run build and commit steps during pull request events instead of main branch pushes.
  * Adjusted workflow to push built files directly to the pull request's source branch.
  * Refined security analysis workflow by specifying explicit permissions for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->