### PR TITLE
feat: add pre-compilation state validation

### DIFF
--- a/Packages/src/Editor/Tools/Util/CompileController.cs
+++ b/Packages/src/Editor/Tools/Util/CompileController.cs
@@ -11,7 +11,7 @@ namespace io.github.hatayama.uMCP
     /// A class that asynchronously executes Unity's compilation process and monitors the results.
     /// It handles starting compilation, monitoring its progress, and retrieving the results.
     /// </summary>
-    public class CompileChecker : System.IDisposable
+    public class CompileChecker : IDisposable
     {
         private bool isCompiling = false;
         private List<CompilerMessage> compileMessages = new List<CompilerMessage>();


### PR DESCRIPTION
## Overview
This PR adds pre-compilation state validation to prevent compilation conflicts and improve system stability. The CompileCommand now checks for various blocking conditions before attempting to compile.

## Details
- Added `ValidateCompilationState()` method to CompileCommand that checks:
  - Whether compilation is already in progress (`EditorApplication.isCompiling`)
  - Whether domain reload is in progress (`McpSessionManager.instance.IsDomainReloadInProgress`)
  - Whether editor is updating (`EditorApplication.isUpdating`)
- Returns early with appropriate error messages if any blocking condition is detected
- Ensures compilation only proceeds when the system is in a stable state
- Improved error handling with clear user feedback

## Related Documents
- Unity Editor Compilation API documentation
- uMCP CompileCommand API specification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-compilation validation to prevent starting a compile when the editor is already compiling, updating, or performing a domain reload. Users will now receive immediate feedback if compilation cannot proceed.
* **Refactor**
  * Minor internal code cleanup with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->