### PR TITLE
feat: improve RunTests filter types and enhance MCP enum documentation

### DIFF
--- a/Assets/Tests/Editor/RunTestsToolTests.cs
+++ b/Assets/Tests/Editor/RunTestsToolTests.cs
@@ -35,13 +35,13 @@ namespace io.github.hatayama.uMCP
             // Arrange - Test the Schema object directly
             RunTestsSchema schema = new RunTestsSchema
             {
-                FilterType = TestFilterType.fullclassname,
+                FilterType = TestFilterType.regex,
                 FilterValue = "TestClass",
                 SaveXml = true
             };
 
             // Assert - Schema properties should match what we set
-            Assert.That(schema.FilterType.ToString(), Is.EqualTo("fullclassname"));
+            Assert.That(schema.FilterType.ToString(), Is.EqualTo("regex"));
             Assert.That(schema.FilterValue, Is.EqualTo("TestClass"));
             Assert.That(schema.SaveXml, Is.True);
         }
@@ -74,10 +74,10 @@ namespace io.github.hatayama.uMCP
             System.Reflection.MethodInfo createFilterMethod = typeof(RunTestsTool)
                 .GetMethod("CreateFilter", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             
-            TestExecutionFilter result = (TestExecutionFilter)createFilterMethod.Invoke(runTestsTool, new object[] { "fullclassname", "TestClass" });
+            TestExecutionFilter result = (TestExecutionFilter)createFilterMethod.Invoke(runTestsTool, new object[] { "regex", "TestClass" });
 
             // Assert
-            Assert.That(result.FilterType, Is.EqualTo(TestExecutionFilterType.ClassName));
+            Assert.That(result.FilterType, Is.EqualTo(TestExecutionFilterType.Regex));
             Assert.That(result.FilterValue, Is.EqualTo("TestClass"));
         }
 

--- a/Assets/Tests/Editor/TestSessionManager.cs
+++ b/Assets/Tests/Editor/TestSessionManager.cs
@@ -16,7 +16,6 @@ namespace io.github.hatayama.uMCP
             set
             {
                 testBoolValue = value;
-                Save(true);
             }
         }
 
@@ -26,7 +25,6 @@ namespace io.github.hatayama.uMCP
             set
             {
                 testIntValue = value;
-                Save(true);
             }
         }
 
@@ -36,7 +34,6 @@ namespace io.github.hatayama.uMCP
             set
             {
                 testStringValue = value ?? "";
-                Save(true);
             }
         }
 
@@ -46,7 +43,6 @@ namespace io.github.hatayama.uMCP
             set
             {
                 testFloatValue = value;
-                Save(true);
             }
         }
 
@@ -56,7 +52,6 @@ namespace io.github.hatayama.uMCP
             testIntValue = 0;
             testStringValue = "";
             testFloatValue = 0.0f;
-            Save(true);
         }
 
         public string GetAllValuesAsString()

--- a/Assets/Tests/_Test_For_Test_.meta
+++ b/Assets/Tests/_Test_For_Test_.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce20d8d109e874a668e6725e21dd9837
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/_Test_For_Test_/ConsoleLogRetrieverTests.cs
+++ b/Assets/Tests/_Test_For_Test_/ConsoleLogRetrieverTests.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+namespace io.github.hatayama.uMCP._Test
+{
+    public class Test_For_Test
+    {
+        [Test]
+        public void Test1()
+        {
+            Assert.True(true);
+        }
+        
+        [Test]
+        public void Test2()
+        {
+            Assert.True(true);
+        }
+    }
+}

--- a/Assets/Tests/_Test_For_Test_/ConsoleLogRetrieverTests.cs.meta
+++ b/Assets/Tests/_Test_For_Test_/ConsoleLogRetrieverTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac213ab952b3e4967bd69fae759402e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/_Test_For_Test_/uMCP.test_for_test.Editor.asmdef
+++ b/Assets/Tests/_Test_For_Test_/uMCP.test_for_test.Editor.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "uMCP.test_for_test.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:214998e563c124e8a88199b2dd1f522d",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/_Test_For_Test_/uMCP.test_for_test.Editor.asmdef.meta
+++ b/Assets/Tests/_Test_For_Test_/uMCP.test_for_test.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2dc6b4611b96a49c5bd291cb7f5dc3ff
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsSchema.cs
@@ -1,9 +1,12 @@
+using System.ComponentModel;
+
 namespace io.github.hatayama.uMCP
 {
     public class FindGameObjectsSchema : BaseToolSchema
     {
         // Search criteria
         public string NamePattern { get; set; } = "";
+        [Description("Search mode (Exact(0), Path(1), Regex(2), Contains(3))")]
         public SearchMode SearchMode { get; set; } = SearchMode.Exact;
         public string[] RequiredComponents { get; set; } = new string[0];
         public string Tag { get; set; } = "";

--- a/Packages/src/Editor/Api/McpTools/GetLogs/GetLogsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/GetLogs/GetLogsSchema.cs
@@ -23,7 +23,7 @@ namespace io.github.hatayama.uMCP
         /// <summary>
         /// Log type to filter (Error, Warning, Log, All)
         /// </summary>
-        [Description("Log type to filter (Error, Warning, Log, All)")]
+        [Description("Log type to filter (Error(2), Warning(1), Log(0), All(3))")]
         public McpLogType LogType { get; set; } = McpLogType.All;
 
         /// <summary>

--- a/Packages/src/Editor/Api/McpTools/GetMenuItems/GetMenuItemsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/GetMenuItems/GetMenuItemsSchema.cs
@@ -38,7 +38,7 @@ namespace io.github.hatayama.uMCP
         /// <summary>
         /// Type of filter to apply (contains, exact, startswith)
         /// </summary>
-        [Description("Type of filter to apply (contains, exact, startswith)")]
+        [Description("Type of filter to apply (contains(0), exact(1), startswith(2))")]
         public MenuItemFilterType FilterType { get; set; } = MenuItemFilterType.contains;
 
         /// <summary>

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsSchema.cs
@@ -9,7 +9,9 @@ namespace io.github.hatayama.uMCP
     public enum TestFilterType
     {
         all,
-        fullclassname
+        exact,
+        regex,
+        assembly
     }
 
     /// <summary>
@@ -19,25 +21,24 @@ namespace io.github.hatayama.uMCP
     public class RunTestsSchema : BaseToolSchema
     {
         /// <summary>
-        /// Test mode (EditMode or PlayMode)
+        /// Test mode - EditMode(0), PlayMode(1)
         /// </summary>
-        [Description("Test mode (EditMode or PlayMode)")]
+        [Description("Test mode - EditMode(0), PlayMode(1)")]
         public TestMode TestMode { get; set; } = TestMode.EditMode;
 
         /// <summary>
-        /// Type of test filter
+        /// Type of test filter - all(0), exact(1), regex(2), assembly(3)
         /// </summary>
-        [Description("Type of test filter")]
+        [Description("Type of test filter - all(0), exact(1), regex(2), assembly(3)")]
         public TestFilterType FilterType { get; set; } = TestFilterType.all;
 
         /// <summary>
         /// Filter value (specify when filterType is not all)
-        /// • fullclassname: Full class name (e.g.: io.github.hatayama.uMCP.CompileCommandTests)
-        /// • namespace: Namespace (e.g.: io.github.hatayama.uMCP)
-        /// • testname: Individual test name
-        /// • assembly: Assembly name
+        /// • exact: Individual test method name (e.g.: io.github.hatayama.uMCP.ConsoleLogRetrieverTests.GetAllLogs_WithMaskAllOff_StillReturnsAllLogs)
+        /// • regex: Class name or namespace (e.g.: io.github.hatayama.uMCP.ConsoleLogRetrieverTests, io.github.hatayama.uMCP)
+        /// • assembly: Assembly name (e.g.: uMCP.Tests.Editor)
         /// </summary>
-        [Description("Filter value (specify when filterType is not all)\n• fullclassname: Full class name (e.g.: io.github.hatayama.uMCP.CompileCommandTests)\n• namespace: Namespace (e.g.: io.github.hatayama.uMCP)\n• testname: Individual test name\n• assembly: Assembly name")]
+        [Description("Filter value (specify when filterType is not all)\n• exact: Individual test method name (e.g.: io.github.hatayama.uMCP.ConsoleLogRetrieverTests.GetAllLogs_WithMaskAllOff_StillReturnsAllLogs)\n• regex: Class name or namespace (e.g.: io.github.hatayama.uMCP.ConsoleLogRetrieverTests, io.github.hatayama.uMCP)\n• assembly: Assembly name (e.g.: uMCP.Tests.Editor)")]
         public string FilterValue { get; set; } = "";
 
         /// <summary>

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsTool.cs
@@ -12,7 +12,7 @@ namespace io.github.hatayama.uMCP
     public class RunTestsTool : AbstractUnityTool<RunTestsSchema, RunTestsResponse>
     {
         public override string ToolName => "run-tests";
-        public override string Description => "Execute Unity tests using Test Runner";
+        public override string Description => "Execute Unity Test Runner with advanced filtering options - exact test methods, regex patterns for classes/namespaces, assembly filtering";
 
         protected override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters)
         {
@@ -58,9 +58,8 @@ namespace io.github.hatayama.uMCP
             return filterType.ToLower() switch
             {
                 "all" => TestExecutionFilter.All(), // Run all tests
-                "fullclassname" => TestExecutionFilter.ByClassName(filterValue), // Full class name (e.g.: io.github.hatayama.uMCP.CompileCommandTests)
-                "namespace" => TestExecutionFilter.ByNamespace(filterValue), // Namespace (e.g.: io.github.hatayama.uMCP)
-                "testname" => TestExecutionFilter.ByTestName(filterValue), // Individual test name
+                "exact" => TestExecutionFilter.ByTestName(filterValue), // Individual test method (exact match)
+                "regex" => TestExecutionFilter.ByClassName(filterValue), // Class name or namespace (regex pattern)
                 "assembly" => TestExecutionFilter.ByAssemblyName(filterValue), // Assembly name
                 _ => throw new ArgumentException($"Unsupported filter type: {filterType}")
             };

--- a/Packages/src/Editor/Api/McpTools/UnitySearch/UnitySearchSchema.cs
+++ b/Packages/src/Editor/Api/McpTools/UnitySearch/UnitySearchSchema.cs
@@ -90,7 +90,7 @@ namespace io.github.hatayama.uMCP
         /// <summary>
         /// Search flags for controlling Unity Search behavior
         /// </summary>
-        [Description("(Optional) Search flags for controlling Unity Search behavior (default: Default)")]
+        [Description("(Optional) Search flags for controlling Unity Search behavior (default: Default(0), Synchronous(1), WantsMore(2), Packages(4), Sorted(8))")]
         public UnitySearchFlags SearchFlags { get; set; } = UnitySearchFlags.Default;
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace io.github.hatayama.uMCP
         /// <summary>
         /// Output file format when SaveToFile is enabled (JSON, CSV, TSV)
         /// </summary>
-        [Description("(Optional) Output file format when SaveToFile is enabled (default: JSON)")]
+        [Description("(Optional) Output file format when SaveToFile is enabled (default: JSON(0), CSV(1), TSV(2))")]
         public SearchOutputFormat OutputFormat { get; set; } = SearchOutputFormat.JSON;
 
         /// <summary>

--- a/Packages/src/Editor/Core/CoreTools/TestRunner/PlayModeTestExecuter.cs
+++ b/Packages/src/Editor/Core/CoreTools/TestRunner/PlayModeTestExecuter.cs
@@ -93,14 +93,13 @@ namespace io.github.hatayama.uMCP
             {
                 switch (filter.FilterType)
                 {
-                    case TestExecutionFilterType.TestName:
+                    case TestExecutionFilterType.Exact:
+                        // Use testNames for exact matching (individual test methods)
                         unityFilter.testNames = new string[] { filter.FilterValue };
                         break;
-                    case TestExecutionFilterType.ClassName:
-                        unityFilter.testNames = new string[] { filter.FilterValue };
-                        break;
-                    case TestExecutionFilterType.Namespace:
-                        unityFilter.testNames = new string[] { filter.FilterValue };
+                    case TestExecutionFilterType.Regex:
+                        // Use groupNames with regex for pattern matching (classes, namespaces)
+                        unityFilter.groupNames = new string[] { "^" + filter.FilterValue.Replace(".", "\\.") + "\\." };
                         break;
                     case TestExecutionFilterType.AssemblyName:
                         unityFilter.assemblyNames = new string[] { filter.FilterValue };

--- a/Packages/src/Editor/Core/CoreTools/TestRunner/TestExecutionFilter.cs
+++ b/Packages/src/Editor/Core/CoreTools/TestRunner/TestExecutionFilter.cs
@@ -11,19 +11,14 @@ namespace io.github.hatayama.uMCP
         All,
         
         /// <summary>
-        /// Filter by a specific test name.
+        /// Filter by exact test method name (complete match).
         /// </summary>
-        TestName,
+        Exact,
         
         /// <summary>
-        /// Filter by class name.
+        /// Filter by regex pattern (class name or namespace).
         /// </summary>
-        ClassName,
-        
-        /// <summary>
-        /// Filter by namespace.
-        /// </summary>
-        Namespace,
+        Regex,
         
         /// <summary>
         /// Filter by assembly name.
@@ -45,9 +40,8 @@ namespace io.github.hatayama.uMCP
         /// <summary>
         /// The specific value to filter tests by, based on the FilterType.
         /// Examples:
-        /// • When FilterType is TestName: "MySpecificTestMethod"
-        /// • When FilterType is ClassName: "io.github.hatayama.uMCP.CompileCommandTests"
-        /// • When FilterType is Namespace: "io.github.hatayama.uMCP"
+        /// • When FilterType is Exact: "io.github.hatayama.uMCP.ConsoleLogRetrieverTests.GetAllLogs_WithMaskAllOff_StillReturnsAllLogs"
+        /// • When FilterType is Regex: "io.github.hatayama.uMCP.ConsoleLogRetrieverTests" or "io.github.hatayama.uMCP"
         /// • When FilterType is AssemblyName: "uMCP.Tests.Editor"
         /// </summary>
         public string FilterValue { get; }
@@ -62,27 +56,19 @@ namespace io.github.hatayama.uMCP
         }
         
         /// <summary>
-        /// Creates a filter by class name.
-        /// </summary>
-        public static TestExecutionFilter ByClassName(string className)
-        {
-            return new TestExecutionFilter(TestExecutionFilterType.ClassName, className);
-        }
-        
-        /// <summary>
-        /// Creates a filter by namespace.
-        /// </summary>
-        public static TestExecutionFilter ByNamespace(string namespaceName)
-        {
-            return new TestExecutionFilter(TestExecutionFilterType.Namespace, namespaceName);
-        }
-        
-        /// <summary>
-        /// Creates a filter by test name.
+        /// Creates a filter by exact test method name.
         /// </summary>
         public static TestExecutionFilter ByTestName(string testName)
         {
-            return new TestExecutionFilter(TestExecutionFilterType.TestName, testName);
+            return new TestExecutionFilter(TestExecutionFilterType.Exact, testName);
+        }
+        
+        /// <summary>
+        /// Creates a filter by regex pattern (class name or namespace).
+        /// </summary>
+        public static TestExecutionFilter ByClassName(string className)
+        {
+            return new TestExecutionFilter(TestExecutionFilterType.Regex, className);
         }
         
         /// <summary>

--- a/Packages/src/FEATURES_ja.md
+++ b/Packages/src/FEATURES_ja.md
@@ -63,10 +63,12 @@
 ### 3. run-tests
 - **説明**: Unity Test Runnerを実行し、包括的なレポート付きでテスト結果を取得します
 - **パラメータ**: 
-  - `FilterType` (enum): テストフィルタのタイプ - "all", "fullclassname"（デフォルト: "all"）
+  - `FilterType` (enum): テストフィルタのタイプ - "all"(0), "exact"(1), "regex"(2), "assembly"(3)（デフォルト: "all"）
   - `FilterValue` (string): フィルタ値（FilterTypeがall以外の場合に指定）（デフォルト: ""）
-    - `fullclassname`: 完全クラス名（例：io.github.hatayama.uMCP.CompileCommandTests）
-  - `TestMode` (enum): テストモード - "EditMode", "PlayMode"（デフォルト: "EditMode"）
+    - `exact`: 個別テストメソッド名（完全一致）（例：io.github.hatayama.uMCP.ConsoleLogRetrieverTests.GetAllLogs_WithMaskAllOff_StillReturnsAllLogs）
+    - `regex`: クラス名または名前空間（正規表現パターン）（例：io.github.hatayama.uMCP.ConsoleLogRetrieverTests, io.github.hatayama.uMCP）
+    - `assembly`: アセンブリ名（例：uMCP.Tests.Editor）
+  - `TestMode` (enum): テストモード - "EditMode"(0), "PlayMode"(1)（デフォルト: "EditMode"）
     - ⚠️ **PlayMode注意**: PlayModeテスト実行時は、一時的にdomain reloadが無効化されます
   - `SaveXml` (boolean): テスト結果をXMLファイルとして保存するかどうか（デフォルト: false）
     - XMLファイルは `TestResults/` フォルダに保存されます（プロジェクトルート）


### PR DESCRIPTION
## Overview
This PR significantly improves the RunTests tool by consolidating filter types and enhancing enum documentation across all MCP tools.

## Details
- **Consolidated RunTests filter types**: Reduced from 5 filter types to 4 streamlined options (all, exact, regex, assembly)
- **Fixed Unity Test Runner API usage**: Properly implemented testNames vs groupNames for different filtering scenarios
- **Enhanced enum documentation**: Added numeric value mappings in Description attributes for all MCP tool enums, improving AI/user understanding
- **Updated test files**: Modified existing tests to work with new filter structure
- **Comprehensive documentation updates**: Updated FEATURES_ja.md and inline documentation

### Key Changes:
1. **TestFilterType enum**: Renamed `fullclassname` to `regex` and added `exact` and `assembly` options
2. **Performance optimization**: Uses Unity's recommended testNames for exact matches and groupNames for regex patterns
3. **MCP client compatibility**: All enum parameters now show numeric correspondences (e.g., "EditMode(0), PlayMode(1)")
4. **Test execution improvements**: Individual test methods and class/namespace filtering now work correctly

## Related Documents
- [Unity Test Runner API Documentation](https://docs.unity3d.com/Manual/testing-editortestsrunner.html)
- Internal test files demonstrating proper filter usage patterns