### PR TITLE
refactor: unify tool descriptions using McpTool attribute

### DIFF
--- a/Assets/Editor/CustomCommandSamples/GetProjectInfo/GetProjectInfoSchema.cs
+++ b/Assets/Editor/CustomCommandSamples/GetProjectInfo/GetProjectInfoSchema.cs
@@ -1,0 +1,11 @@
+namespace io.github.hatayama.uMCP
+{
+    /// <summary>
+    /// Schema for GetProjectInfo tool parameters
+    /// This tool takes no parameters
+    /// </summary>
+    public class GetProjectInfoSchema : BaseToolSchema
+    {
+        // No parameters needed for this tool
+    }
+}

--- a/Assets/Editor/CustomCommandSamples/GetProjectInfo/GetProjectInfoSchema.cs.meta
+++ b/Assets/Editor/CustomCommandSamples/GetProjectInfo/GetProjectInfoSchema.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4df81a4747e3c4b318413d165360043e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/CustomCommandSamples/GetProjectInfo/GetProjectInfoTool.cs
+++ b/Assets/Editor/CustomCommandSamples/GetProjectInfo/GetProjectInfoTool.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using UnityEngine;
 
 namespace io.github.hatayama.uMCP
@@ -8,17 +7,13 @@ namespace io.github.hatayama.uMCP
     /// Project information retrieval custom tool
     /// Example of retrieving detailed Unity project information
     /// </summary>
-    public class GetProjectInfoTool : IUnityTool
+    [McpTool(Description = "Get detailed Unity project information")]
+    public class GetProjectInfoTool : AbstractUnityTool<GetProjectInfoSchema, GetProjectInfoResponse>
     {
-        public string ToolName => "getprojectinfo";
-        public string Description => "Get detailed Unity project information";
+        public override string ToolName => "get-project-info";
 
-        public ToolParameterSchema ParameterSchema => new ToolParameterSchema();
-
-        public Task<BaseToolResponse> ExecuteAsync(JToken paramsToken)
+        protected override Task<GetProjectInfoResponse> ExecuteAsync(GetProjectInfoSchema parameters)
         {
-            Debug.Log("GetProjectInfo tool executed");
-            
             GetProjectInfoResponse response = new GetProjectInfoResponse
             {
                 ProjectName = Application.productName,
@@ -46,7 +41,7 @@ namespace io.github.hatayama.uMCP
                 ToolName = ToolName
             };
             
-            return Task.FromResult<BaseToolResponse>(response);
+            return Task.FromResult(response);
         }
     }
 } 

--- a/Assets/Editor/CustomCommandSamples/GetVersion/GetVersionSchema.cs
+++ b/Assets/Editor/CustomCommandSamples/GetVersion/GetVersionSchema.cs
@@ -1,0 +1,11 @@
+namespace io.github.hatayama.uMCP
+{
+    /// <summary>
+    /// Schema for GetVersion tool parameters
+    /// This tool takes no parameters
+    /// </summary>
+    public class GetVersionSchema : BaseToolSchema
+    {
+        // No parameters needed for this tool
+    }
+}

--- a/Assets/Editor/CustomCommandSamples/GetVersion/GetVersionSchema.cs.meta
+++ b/Assets/Editor/CustomCommandSamples/GetVersion/GetVersionSchema.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63b2d0366b85b480cb054e1d267c2657
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/CustomCommandSamples/GetVersion/GetVersionTool.cs
+++ b/Assets/Editor/CustomCommandSamples/GetVersion/GetVersionTool.cs
@@ -1,7 +1,5 @@
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using UnityEngine;
-
 
 namespace io.github.hatayama.uMCP
 {
@@ -10,14 +8,12 @@ namespace io.github.hatayama.uMCP
     /// Get Unity version information
     /// Created as an example of adding new tools
     /// </summary>
-    public class GetVersionTool : IUnityTool
+    [McpTool(Description = "Get Unity version and project information")]
+    public class GetVersionTool : AbstractUnityTool<GetVersionSchema, GetVersionResponse>
     {
-        public string ToolName => "getversion";
-        public string Description => "Get Unity version and project information";
+        public override string ToolName => "get-version";
 
-        public ToolParameterSchema ParameterSchema => new ToolParameterSchema();
-
-        public Task<BaseToolResponse> ExecuteAsync(JToken paramsToken)
+        protected override Task<GetVersionResponse> ExecuteAsync(GetVersionSchema parameters)
         {
             McpLogger.LogDebug("GetVersion request received");
             
@@ -36,7 +32,7 @@ namespace io.github.hatayama.uMCP
             
             McpLogger.LogDebug($"GetVersion completed: Unity {Application.unityVersion}");
             
-            return Task.FromResult<BaseToolResponse>(response);
+            return Task.FromResult(response);
         }
     }
 } 

--- a/Assets/Editor/CustomCommandSamples/HelloWorld/HelloWorldTool.cs
+++ b/Assets/Editor/CustomCommandSamples/HelloWorld/HelloWorldTool.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using UnityEngine;
-using System.Collections.Generic;
 
 namespace io.github.hatayama.uMCP
 {
@@ -9,13 +7,11 @@ namespace io.github.hatayama.uMCP
     /// Hello World custom tool - Type-safe implementation using Schema and Response
     /// Basic implementation example of a custom tool with strongly typed parameters and response
     /// </summary>
+    [McpTool(Description = "Personalized hello world tool with name parameter")]
     public class HelloWorldTool : AbstractUnityTool<HelloWorldSchema, HelloWorldResponse>
     {
-        public override string ToolName => "helloworld";
-        public override string Description => "Personalized hello world tool with name parameter";
-
-
-
+        public override string ToolName => "hello-world";
+        
         protected override Task<HelloWorldResponse> ExecuteAsync(HelloWorldSchema parameters)
         {
             // Type-safe parameter access - no more string parsing!

--- a/Assets/Tests/Editor/FindGameObjectsToolTests.cs
+++ b/Assets/Tests/Editor/FindGameObjectsToolTests.cs
@@ -37,12 +37,6 @@ namespace io.github.hatayama.uMCP
             Assert.That(tool.ToolName, Is.EqualTo("find-game-objects"));
         }
         
-        [Test]
-        public void Description_ReturnsNonEmptyString()
-        {
-            Assert.That(tool.Description, Is.Not.Null);
-            Assert.That(tool.Description, Is.Not.Empty);
-        }
         
         [Test]
         public async Task ExecuteAsync_WithNamePattern_FindsMatchingObjects()

--- a/Assets/Tests/Editor/GetHierarchyToolTests.cs
+++ b/Assets/Tests/Editor/GetHierarchyToolTests.cs
@@ -30,12 +30,6 @@ namespace io.github.hatayama.uMCP.Tests
             Assert.That(tool.ToolName, Is.EqualTo("get-hierarchy"));
         }
         
-        [Test]
-        public void Description_ReturnsNonEmptyString()
-        {
-            Assert.That(tool.Description, Is.Not.Null);
-            Assert.That(tool.Description, Is.Not.Empty);
-        }
         
         [Test]
         public async Task ExecuteAsync_WithDefaultParameters_ReturnsValidResponse()

--- a/Packages/src/Editor/ARCHITECTURE.md
+++ b/Packages/src/Editor/ARCHITECTURE.md
@@ -56,11 +56,12 @@ The system is centered around the **Tool Pattern**. Each action that can be trig
 
 - **`IUnityTool`**: The common interface for all tools.
 - **`AbstractUnityTool<TSchema, TResponse>`**: A generic abstract base class that provides type-safe handling of parameters and responses.
+- **`McpToolAttribute`**: Attribute used to mark tools for automatic registration, including Description configuration.
 - **`UnityToolRegistry`**: A central registry that discovers and holds all available tools.
 - **`UnityApiHandler`**: These classes receive a tool name and parameters, look up the tool in the registry, and execute it.
 - **`McpSecurityChecker`**: Validates tool execution permissions based on security settings.
 
-This pattern makes the system highly extensible. To add a new feature, a developer simply needs to create a new class that implements `IUnityTool` and decorate it with the `[McpTool]` attribute. The system will automatically discover and expose it.
+This pattern makes the system highly extensible. To add a new feature, a developer simply needs to create a new class that implements `IUnityTool` and decorate it with the `[McpTool(Description = "...")]` attribute. The system will automatically discover and expose it.
 
 ### 2.2. Security Architecture
 The system implements comprehensive security controls to prevent unauthorized tool execution:
@@ -108,7 +109,9 @@ classDiagram
 
     class McpToolAttribute {
         <<attribute>>
-        +AutoRegister: bool
+        +Description: string
+        +DisplayDevelopmentOnly: bool
+        +RequiredSecuritySetting: SecuritySettings
     }
 
     class CompileCommand {

--- a/Packages/src/Editor/Api/McpTools/ClearConsole/ClearConsoleTool.cs
+++ b/Packages/src/Editor/Api/McpTools/ClearConsole/ClearConsoleTool.cs
@@ -11,11 +11,10 @@ namespace io.github.hatayama.uMCP
     /// - ClearConsoleSchema: Type-safe parameter schema
     /// - ClearConsoleResponse: Type-safe response structure
     /// </summary>
-    [McpTool]
+    [McpTool(Description = "Clear Unity console logs")]
     public class ClearConsoleTool : AbstractUnityTool<ClearConsoleSchema, ClearConsoleResponse>
     {
         public override string ToolName => "clear-console";
-        public override string Description => "Clear Unity console logs";
 
         /// <summary>
         /// Execute console clear tool

--- a/Packages/src/Editor/Api/McpTools/Compile/CompileTool.cs
+++ b/Packages/src/Editor/Api/McpTools/Compile/CompileTool.cs
@@ -9,11 +9,10 @@ namespace io.github.hatayama.uMCP
     /// Compile tool handler - Type-safe implementation using Schema and Response
     /// Handles Unity project compilation with optional force recompile
     /// </summary>
-    [McpTool]
+    [McpTool(Description = "Execute Unity project compilation")]
     public class CompileTool : AbstractUnityTool<CompileSchema, CompileResponse>
     {
         public override string ToolName => "compile";
-        public override string Description => "Execute Unity project compilation";
 
         /// <summary>
         /// Execute compile tool

--- a/Packages/src/Editor/Api/McpTools/Core/AbstractUnityTool.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/AbstractUnityTool.cs
@@ -19,7 +19,6 @@ namespace io.github.hatayama.uMCP
         where TResponse : BaseToolResponse
     {
         public abstract string ToolName { get; }
-        public abstract string Description { get; }
 
         /// <summary>
         /// Automatically generates parameter schema from TSchema type

--- a/Packages/src/Editor/Api/McpTools/Core/IUnityTool.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/IUnityTool.cs
@@ -30,10 +30,6 @@ namespace io.github.hatayama.uMCP
         /// </summary>
         string ToolName { get; }
         
-        /// <summary>
-        /// Get tool description
-        /// </summary>
-        string Description { get; }
         
         /// <summary>
         /// Get parameter schema information for TypeScript side

--- a/Packages/src/Editor/Api/McpTools/Core/McpToolAttribute.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/McpToolAttribute.cs
@@ -20,6 +20,11 @@ namespace io.github.hatayama.uMCP
         public SecuritySettings RequiredSecuritySetting { get; set; } = SecuritySettings.None;
 
         /// <summary>
+        /// Gets or sets the description of this tool
+        /// </summary>
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
         /// Initialize McpTool attribute
         /// </summary>
         public McpToolAttribute()

--- a/Packages/src/Editor/Api/McpTools/Core/UnityToolRegistry.cs
+++ b/Packages/src/Editor/Api/McpTools/Core/UnityToolRegistry.cs
@@ -249,7 +249,9 @@ namespace io.github.hatayama.uMCP
                 
                 // Check security settings
                 bool isAllowed = McpSecurityChecker.IsToolAllowed(tool.ToolName);
-                string description = tool.Description;
+                
+                // Get description from attribute
+                string description = attribute?.Description ?? "";
                 
                 // Modify description for blocked tools
                 if (!isAllowed)

--- a/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/ExecuteMenuItemTool.cs
+++ b/Packages/src/Editor/Api/McpTools/ExecuteMenuItem/ExecuteMenuItemTool.cs
@@ -10,11 +10,13 @@ namespace io.github.hatayama.uMCP
     /// ExecuteMenuItem tool handler - Executes Unity MenuItems by path
     /// Supports both EditorApplication.ExecuteMenuItem and reflection-based execution
     /// </summary>
-    [McpTool(RequiredSecuritySetting = SecuritySettings.AllowMenuItemExecution)]
+    [McpTool(
+        Description = "Execute Unity MenuItem by path",
+        RequiredSecuritySetting = SecuritySettings.AllowMenuItemExecution
+    )]
     public class ExecuteMenuItemTool : AbstractUnityTool<ExecuteMenuItemSchema, ExecuteMenuItemResponse>
     {
         public override string ToolName => "execute-menu-item";
-        public override string Description => "Execute Unity MenuItem by path";
 
         protected override Task<ExecuteMenuItemResponse> ExecuteAsync(ExecuteMenuItemSchema parameters)
         {

--- a/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/FindGameObjects/FindGameObjectsTool.cs
@@ -9,11 +9,10 @@ namespace io.github.hatayama.uMCP
     /// - GameObjectFinderService: Core logic for finding GameObjects
     /// - FindGameObjectsSchema: Search parameters
     /// </summary>
-    [McpTool]
+    [McpTool(Description = "Find multiple GameObjects with advanced search criteria (component type, tag, layer, etc.)")]
     public class FindGameObjectsTool : AbstractUnityTool<FindGameObjectsSchema, FindGameObjectsResponse>
     {
         public override string ToolName => "find-game-objects";
-        public override string Description => "Find multiple GameObjects with advanced search criteria (component type, tag, layer, etc.)";
         
         protected override Task<FindGameObjectsResponse> ExecuteAsync(FindGameObjectsSchema parameters)
         {

--- a/Packages/src/Editor/Api/McpTools/GetCommandDetails/GetToolDetailsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/GetCommandDetails/GetToolDetailsTool.cs
@@ -11,11 +11,13 @@ namespace io.github.hatayama.uMCP
     /// - ToolInfo: Data structure for tool details
     /// - GetToolDetailsResponse: Type-safe response structure
     /// </summary>
-    [McpTool(DisplayDevelopmentOnly = true)]
+    [McpTool(
+        Description = "Retrieve detailed information about all registered Unity MCP tools",
+        DisplayDevelopmentOnly = true
+    )]
     public class GetToolDetailsTool : AbstractUnityTool<GetToolDetailsSchema, GetToolDetailsResponse>
     {
         public override string ToolName => "get-tool-details";
-        public override string Description => "Retrieve detailed information about all registered Unity MCP tools";
 
         protected override Task<GetToolDetailsResponse> ExecuteAsync(GetToolDetailsSchema parameters)
         {

--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchyTool.cs
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/GetHierarchyTool.cs
@@ -9,11 +9,10 @@ namespace io.github.hatayama.uMCP
     /// - HierarchySerializer: JSON formatting logic
     /// - HierarchyNode: Data structure for hierarchy nodes
     /// </summary>
-    [McpTool]
+    [McpTool(Description = "Get Unity Hierarchy structure in AI-friendly format")]
     public class GetHierarchyTool : AbstractUnityTool<GetHierarchySchema, GetHierarchyResponse>
     {
         public override string ToolName => "get-hierarchy";
-        public override string Description => "Get Unity Hierarchy structure in AI-friendly format";
         
         protected override Task<GetHierarchyResponse> ExecuteAsync(GetHierarchySchema parameters)
         {

--- a/Packages/src/Editor/Api/McpTools/GetLogs/GetLogsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/GetLogs/GetLogsTool.cs
@@ -8,11 +8,10 @@ namespace io.github.hatayama.uMCP
     /// GetLogs tool handler - Type-safe implementation using Schema and Response
     /// Retrieves Unity console logs with filtering options
     /// </summary>
-    [McpTool]
+    [McpTool(Description = "Retrieve logs from Unity Console")]
     public class GetLogsTool : AbstractUnityTool<GetLogsSchema, GetLogsResponse>
     {
         public override string ToolName => "get-logs";
-        public override string Description => "Retrieve logs from Unity Console";
 
 
 

--- a/Packages/src/Editor/Api/McpTools/GetMenuItems/GetMenuItemsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/GetMenuItems/GetMenuItemsTool.cs
@@ -9,11 +9,10 @@ namespace io.github.hatayama.uMCP
     /// GetMenuItems tool handler - Discovers Unity MenuItems with filtering
     /// Retrieves MenuItem information from all loaded assemblies
     /// </summary>
-    [McpTool]
+    [McpTool(Description = "Retrieve Unity MenuItems with detailed metadata for programmatic execution. Unlike Unity Search menu provider, this provides implementation details (method names, assemblies, execution compatibility) needed for automation and debugging.")]
     public class GetMenuItemsTool : AbstractUnityTool<GetMenuItemsSchema, GetMenuItemsResponse>
     {
         public override string ToolName => "get-menu-items";
-        public override string Description => "Retrieve Unity MenuItems with detailed metadata for programmatic execution. Unlike Unity Search menu provider, this provides implementation details (method names, assemblies, execution compatibility) needed for automation and debugging.";
 
         protected override Task<GetMenuItemsResponse> ExecuteAsync(GetMenuItemsSchema parameters)
         {

--- a/Packages/src/Editor/Api/McpTools/Ping/PingTool.cs
+++ b/Packages/src/Editor/Api/McpTools/Ping/PingTool.cs
@@ -6,11 +6,13 @@ namespace io.github.hatayama.uMCP
     /// Ping tool handler - Type-safe implementation using Schema and Response
     /// Connection test and message echo functionality
     /// </summary>
-    [McpTool(DisplayDevelopmentOnly = true)]
+    [McpTool(
+        DisplayDevelopmentOnly = true,
+        Description = "Connection test and message echo"
+    )]
     public class PingTool : AbstractUnityTool<PingSchema, PingResponse>
     {
         public override string ToolName => "ping";
-        public override string Description => "Connection test and message echo";
 
 
         protected override Task<PingResponse> ExecuteAsync(PingSchema parameters)

--- a/Packages/src/Editor/Api/McpTools/RunTests/RunTestsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/RunTests/RunTestsTool.cs
@@ -8,11 +8,13 @@ namespace io.github.hatayama.uMCP
     /// Test execution tool handler - Type-safe implementation using Schema and Response
     /// Executes tests using Unity Test Runner and returns the results
     /// </summary>
-    [McpTool(RequiredSecuritySetting = SecuritySettings.EnableTestsExecution)]
+    [McpTool(
+        RequiredSecuritySetting = SecuritySettings.EnableTestsExecution,
+        Description = "Execute Unity Test Runner with advanced filtering options - exact test methods, regex patterns for classes/namespaces, assembly filtering"
+    )]
     public class RunTestsTool : AbstractUnityTool<RunTestsSchema, RunTestsResponse>
     {
         public override string ToolName => "run-tests";
-        public override string Description => "Execute Unity Test Runner with advanced filtering options - exact test methods, regex patterns for classes/namespaces, assembly filtering";
 
         protected override async Task<RunTestsResponse> ExecuteAsync(RunTestsSchema parameters)
         {

--- a/Packages/src/Editor/Api/McpTools/SetClientName/SetClientNameTool.cs
+++ b/Packages/src/Editor/Api/McpTools/SetClientName/SetClientNameTool.cs
@@ -7,11 +7,13 @@ namespace io.github.hatayama.uMCP
     /// SetClientName tool handler - Allows MCP clients to register their name
     /// This tool is called by TypeScript clients to identify themselves
     /// </summary>
-    [McpTool(DisplayDevelopmentOnly = true)]
+    [McpTool(
+        Description = "Register client name for identification in Unity MCP server",
+        DisplayDevelopmentOnly = true
+    )]
     public class SetClientNameTool : AbstractUnityTool<SetClientNameSchema, SetClientNameResponse>
     {
         public override string ToolName => "set-client-name";
-        public override string Description => "Register client name for identification in Unity MCP server";
 
         protected override Task<SetClientNameResponse> ExecuteAsync(SetClientNameSchema parameters)
         {

--- a/Packages/src/Editor/Api/McpTools/UnitySearch/GetProviderDetailsTool.cs
+++ b/Packages/src/Editor/Api/McpTools/UnitySearch/GetProviderDetailsTool.cs
@@ -13,7 +13,7 @@ namespace io.github.hatayama.uMCP
     /// - GetProviderDetailsSchema: Input parameters schema
     /// - GetProviderDetailsResponse: Output response schema
     /// </summary>
-    [McpTool]
+    [McpTool(Description = "Get detailed information about Unity Search providers including display names, descriptions, active status, and capabilities")]
     public class GetProviderDetailsTool : AbstractUnityTool<GetProviderDetailsSchema, GetProviderDetailsResponse>
     {
         /// <summary>
@@ -21,10 +21,6 @@ namespace io.github.hatayama.uMCP
         /// </summary>
         public override string ToolName => "get-provider-details";
 
-        /// <summary>
-        /// Tool description for MCP tool registration
-        /// </summary>
-        public override string Description => "Get detailed information about Unity Search providers including display names, descriptions, active status, and capabilities";
 
         /// <summary>
         /// Execute the provider details retrieval tool

--- a/Packages/src/Editor/Api/McpTools/UnitySearch/UnitySearchTool.cs
+++ b/Packages/src/Editor/Api/McpTools/UnitySearch/UnitySearchTool.cs
@@ -12,11 +12,10 @@ namespace io.github.hatayama.uMCP
     /// - UnitySearchSchema: Type-safe parameter schema
     /// - UnitySearchResponse: Type-safe response structure
     /// </summary>
-    [McpTool]
+    [McpTool(Description = "Search Unity project using Unity Search API with comprehensive filtering and export options")]
     public class UnitySearchTool : AbstractUnityTool<UnitySearchSchema, UnitySearchResponse>
     {
         public override string ToolName => "unity-search";
-        public override string Description => "Search Unity project using Unity Search API with comprehensive filtering and export options";
 
         /// <summary>
         /// Execute Unity search tool with type-safe parameters

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -254,11 +254,10 @@ public class MyCustomResponse : BaseToolResponse
 
 **Step 3: Create Tool Class**:
 ```csharp
-[McpTool]  // ← Auto-registered with this attribute
+[McpTool(Description = "Description of my custom tool")]  // ← Auto-registered with this attribute
 public class MyCustomTool : AbstractUnityTool<MyCustomSchema, MyCustomResponse>
 {
-    public override string ToolName => "myCustomTool";
-    public override string Description => "Description of my custom tool";
+    public override string ToolName => "my-custom-tool";
     
     // Executed on main thread
     protected override Task<MyCustomResponse> ExecuteAsync(MyCustomSchema parameters)

--- a/Packages/src/README_ja.md
+++ b/Packages/src/README_ja.md
@@ -253,11 +253,10 @@ public class MyCustomResponse : BaseToolResponse
 
 **ステップ3: ツールクラスの作成**：
 ```csharp
-[McpTool]  // ← この属性により自動登録されます
+[McpTool(Description = "私のカスタムツールの説明")]  // ← この属性により自動登録されます
 public class MyCustomTool : AbstractUnityTool<MyCustomSchema, MyCustomResponse>
 {
-    public override string ToolName => "myCustomTool";
-    public override string Description => "私のカスタムツールの説明";
+    public override string ToolName => "my-custom-tool";
     
     // メインスレッドで実行されます
     protected override Task<MyCustomResponse> ExecuteAsync(MyCustomSchema parameters)


### PR DESCRIPTION
## Overview
This PR refactors the tool description system to use a unified attribute-based approach. Previously, tool descriptions were implemented as abstract properties that had to be overridden in each tool class. Now, descriptions are declared declaratively using the `[McpTool(Description = "...")]` attribute, providing better consistency and maintainability.

## Details
### Key Changes
1. **Enhanced McpToolAttribute**: Added `Description` property to the `McpToolAttribute` class, allowing descriptions to be specified directly in the attribute.

2. **Updated UnityToolRegistry**: Modified the registry to prioritize description values from attributes over property implementations, maintaining backward compatibility.

3. **Tool Class Refactoring**: Updated all 17 tool classes to use the attribute-based approach:
   - Main tools (14): All core uMCP tools now use `[McpTool(Description = "...")]`
   - Custom samples (3): GetProjectInfo, GetVersion, and HelloWorld tools refactored to use AbstractUnityTool pattern

4. **Interface Cleanup**: Removed the abstract `Description` property from `AbstractUnityTool` and `IUnityTool` interfaces since descriptions are now handled through attributes.

5. **Test Cleanup**: Removed obsolete Description property tests that are no longer applicable.

6. **Documentation Updates**: Updated README.md, README_ja.md, and ARCHITECTURE.md to reflect the new attribute-based approach in code examples.

### Migration Path
- **Backward Compatible**: Existing tools without attributes continue to work
- **Schema Creation**: Added missing schema classes for GetProjectInfo and GetVersion tools
- **Type Safety**: Maintained full type safety throughout the refactoring

## Related Documents
- [Tool Development Guide](Packages/src/README.md#custom-tool-development)
- [Architecture Documentation](Packages/src/Editor/ARCHITECTURE.md)