### PR TITLE
fix: remove JSON depth limit and fix MaxResponseSizeKB threshold

### DIFF
--- a/Packages/src/Editor/Api/JsonRpcProcessor.cs
+++ b/Packages/src/Editor/Api/JsonRpcProcessor.cs
@@ -160,7 +160,7 @@ namespace io.github.hatayama.uMCP
             JsonSerializerSettings settings = new JsonSerializerSettings
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                MaxDepth = 10
+                MaxDepth = McpServerConfig.DEFAULT_JSON_MAX_DEPTH
             };
             
             try
@@ -227,7 +227,7 @@ namespace io.github.hatayama.uMCP
             JsonSerializerSettings settings = new JsonSerializerSettings
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                MaxDepth = 10
+                MaxDepth = McpServerConfig.DEFAULT_JSON_MAX_DEPTH
             };
             
             return JsonConvert.SerializeObject(errorResponse, Formatting.None, settings);

--- a/Packages/src/Editor/Server/McpServerConfig.cs
+++ b/Packages/src/Editor/Server/McpServerConfig.cs
@@ -79,5 +79,11 @@ namespace io.github.hatayama.uMCP
         /// ISO format date and time string.
         /// </summary>
         public const string ISO_DATETIME_FORMAT = "yyyy-MM-ddTHH:mm:ss.fffZ";
+        
+        /// <summary>
+        /// Default maximum depth for JSON serialization.
+        /// Set to int.MaxValue to effectively disable depth limiting while preventing infinite loops.
+        /// </summary>
+        public const int DEFAULT_JSON_MAX_DEPTH = int.MaxValue;
     }
 } 


### PR DESCRIPTION
## Overview
Fixes timeout issues with deep hierarchy structures and resolves MaxResponseSizeKB parameter being ignored. This PR removes artificial JSON depth limitations and improves response size calculation accuracy.

## Details
### Issues Fixed
1. **JSON MaxDepth Timeout Issue**: Previously hardcoded `MaxDepth = 10` in JSON serialization caused timeouts when hierarchy depth exceeded 10 levels
2. **MaxResponseSizeKB Parameter Ignored**: Response size calculation was inaccurate due to using Unity's JsonUtility instead of Newtonsoft.Json, and threshold condition was incorrect

### Changes Made
1. **Remove JSON Depth Limitation**:
   - Replace hardcoded `MaxDepth = 10` with configurable `McpServerConfig.DEFAULT_JSON_MAX_DEPTH`
   - Set default value to `int.MaxValue` to effectively disable depth limiting while preventing infinite loops
   - Applied to both success and error response serialization in JsonRpcProcessor

2. **Fix MaxResponseSizeKB Functionality**:
   - Switch from Unity's `JsonUtility.ToJson()` to `Newtonsoft.Json.JsonConvert.SerializeObject()` for accurate size calculation
   - Use `System.Text.Encoding.UTF8.GetByteCount()` for precise byte count instead of string length estimation
   - Change threshold condition from `>` to `>=` to properly trigger file export at the specified size limit

### Technical Benefits
- Hierarchy structures of any depth can now be processed without artificial JSON serialization limits
- MaxResponseSizeKB parameter works correctly, automatically saving large responses to files
- Consistent JSON serialization settings across all response types
- More accurate memory usage estimation

## Related Documents
- Issue: MaxDepth=10 causes timeout but MaxDepth=9 works fine
- Issue: MaxResponseSizeKB parameter being ignored during response processing