### PR TITLE
fix: replace JsonUtility with Newtonsoft.Json in file export

### DIFF
--- a/Packages/src/Editor/Api/McpTools/GetHierarchy/HierarchyResultExporter.cs
+++ b/Packages/src/Editor/Api/McpTools/GetHierarchy/HierarchyResultExporter.cs
@@ -47,8 +47,14 @@ namespace io.github.hatayama.uMCP
                 Context = context
             };
             
-            // Export to JSON
-            string jsonContent = JsonUtility.ToJson(exportData, true);
+            // Export to JSON using Newtonsoft.Json for proper serialization
+            var settings = new Newtonsoft.Json.JsonSerializerSettings
+            {
+                ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore,
+                MaxDepth = McpServerConfig.DEFAULT_JSON_MAX_DEPTH,
+                Formatting = Newtonsoft.Json.Formatting.Indented
+            };
+            string jsonContent = Newtonsoft.Json.JsonConvert.SerializeObject(exportData, settings);
             File.WriteAllText(filePath, jsonContent);
             
             // Return relative path


### PR DESCRIPTION
## Overview
Fixes empty object serialization issue in hierarchy file export. Previously exported JSON files contained empty objects instead of actual hierarchy data due to Unity JsonUtility limitations with readonly fields.

## Details
### Issue Fixed
When MaxResponseSizeKB threshold was exceeded and hierarchy data was exported to JSON files, the exported files contained empty objects `{}` instead of actual hierarchy node data. This was caused by Unity's JsonUtility being unable to properly serialize readonly fields in the HierarchyNodeNested class.

### Root Cause
Unity's JsonUtility has the following limitations:
- Cannot serialize `readonly` fields
- Cannot serialize properties
- Only serializes public fields
- Has limited support for complex object structures

The HierarchyNodeNested class uses readonly fields for immutability:
```csharp
public readonly int id;
public readonly string name;
public readonly int depth;
public readonly bool isActive;
public readonly string[] components;
public readonly List<HierarchyNodeNested> children;
```

### Solution
Replace Unity JsonUtility with Newtonsoft.Json in HierarchyResultExporter:
- Use `JsonConvert.SerializeObject()` instead of `JsonUtility.ToJson()`
- Configure proper serialization settings with ReferenceLoopHandling and MaxDepth
- Enable indented formatting for better readability
- Ensure consistent JSON handling across the entire codebase

### Before Fix
```json
{
  "ExportTimestamp": "2025-07-11 02:22:57",
  "Hierarchy": [{}, {}, {}, {}, {}, {}],
  "Context": {}
}
```

### After Fix
```json
{
  "ExportTimestamp": "2025-07-11 02:25:52",
  "Hierarchy": [
    {
      "id": 24432,
      "name": "Main Camera",
      "depth": 0,
      "isActive": true,
      "components": ["Transform", "Camera", "AudioListener"],
      "children": []
    }
  ],
  "Context": {
    "sceneType": "editor",
    "sceneName": "SampleScene",
    "nodeCount": 6,
    "maxDepth": 4
  }
}
```

## Related Documents
- Related to PR #190: JSON depth limit and MaxResponseSizeKB threshold fixes
- Unity JsonUtility documentation: Limited serialization capabilities for readonly fields